### PR TITLE
Bump version to 1.0.9

### DIFF
--- a/daisy/__init__.py
+++ b/daisy/__init__.py
@@ -17,7 +17,7 @@ All algorithms support top-k search via searchIndex(query, k) and range
 (distance-r) search via searchIndex(query, SearchConfig(type=QueryType.RANGE, r=r)).
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.9"
 __author__ = ""
 
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "daisy-exact-search"
-version = "1.0.8"
+version = "1.0.9"
 description = "DaiSy: A Library for Scalable Data Series Similarity Search"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools.command.build_py import build_py as _build_py
 from setuptools.command.build_ext import build_ext as _build_ext
 
 # Version
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 
 # Detect platform
 IS_MACOS = sys.platform == "darwin"


### PR DESCRIPTION
Syncs the version string across pyproject.toml, setup.py, and daisy/__init__.py (previously drifted: 1.0.8 / 1.0.8 / 1.0.0). Merging this to main will trigger the pypi-release workflow to publish 1.0.9, since 1.0.8 is already live on PyPI.